### PR TITLE
Parse block_src with test

### DIFF
--- a/src/organum/core.clj
+++ b/src/organum/core.clj
@@ -71,7 +71,7 @@
       (section (count prefix) text tags kw))))
 
 (defn parse-block [ln]
-  (let [block-re #"^\s*#\+(BEGIN|END)_(\w*)\s*([0-9A-Za-z_\-]*)?"
+  (let [block-re #"^\s*#\+(BEGIN|END)_(\w*)\s*([0-9A-Za-z_\-]*)?.*"
         [_ _ type qualifier] (re-matches block-re ln)]
     (block type qualifier)))
 

--- a/test/organum/core_test.clj
+++ b/test/organum/core_test.clj
@@ -14,6 +14,11 @@
     (is (= (parse-block "  #+BEGIN_WIBBLE minor")
            (block "WIBBLE" "minor")))))
 
+(deftest test-src-block
+  (testing "Parsing block heeader"
+    (is (= (parse-block "  #+BEGIN_SRC minor :tangle blah")
+           (block "SRC" "minor")))))
+
 (deftest test-testfile
   (testing "Parsing test.org"
     (let [sections (parse-file (io/resource "test.org"))]


### PR DESCRIPTION
Allow parsing of begin_src with tangle, etc variables on the same line.
