### PR TITLE
Excess slashes escaping whitespace class and '|'

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.gmorpheme/organum "0.1.2"
+(defproject org.clojars.gmorpheme/organum "0.1.3"
   :description "Org-mode parser in clojure"
   :url "https://github.com/gmorpheme/organum"
   :license {:name "Eclipse Public License"

--- a/src/organum/core.clj
+++ b/src/organum/core.clj
@@ -25,7 +25,7 @@
         unordered-list-re #"^\s*(-|\+|\s+[*])\s+.*"
         metadata-re #"^\s*(CLOCK|DEADLINE|START|CLOSED|SCHEDULED):.*"
         table-sep-re #"^\s*\|[-\|\+]*\s*$"
-        table-row-re #"^\\s*\\|.*"
+        table-row-re #"^\s*\|.*"
         inline-example-re #"^\s*:\s.*"
         horiz-re #"^\s*-{5,}\s*$"]
     (cond


### PR DESCRIPTION
Table-Row is catching things that should be paragraphs due to excess slashes causing the whitespace class and the "|" to be unescaped. The result is that `.*` becomes an alternative to the aborted remainder of the regex.
